### PR TITLE
Minify rendered HTML

### DIFF
--- a/bin/dreamuploader
+++ b/bin/dreamuploader
@@ -2,6 +2,7 @@
 
 import base64
 import sys
+from htmlmin.minify import html_minify
 from jinja2 import Environment, PackageLoader, select_autoescape
 import klein
 from twisted.python import log
@@ -25,7 +26,7 @@ app = klein.Klein()
 def index(request):
     request.setHeader('Content-Type', 'text/html')
     template = env.get_template('index.html')
-    return template.render()
+    return html_minify(template.render())
 
 @app.route('/upload', methods=['POST'])
 def post(request):

--- a/dreamuploader/templates/index.html
+++ b/dreamuploader/templates/index.html
@@ -16,7 +16,7 @@
           <table cellspacing="0" cellpadding="2">
             <tr>
               <td align="RIGHT">
-                <label for="vmfile">VMU&nbsp;File</label>
+                <label for="vmfile">VMU File</label>
               </td>
               <td>
                 <input type="VMFILE" name="vmfile">
@@ -37,7 +37,7 @@
             </tr>
             <tr>
               <td align="CENTER" colspan="2">
-                <a href="/files">Browse Files</a>
+                <a href="/files/">Browse Files</a>
               </td>
             </tr>
           </table>

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ setup(name='dreamuploader',
       scripts=['bin/dreamuploader'],
       install_requires=[
         'attrs',
-        'klein',
+        'django-htmlmin',
         'jinja2',
+        'klein',
         'q',
         'twisted'
       ],


### PR DESCRIPTION
This ensures HTML responses are as small as possible, and take a little less time to squeeze through the 33.6 kbps modem!